### PR TITLE
Handle chat_id migration

### DIFF
--- a/main.py
+++ b/main.py
@@ -42,6 +42,7 @@ def start(bot_token: str, state_file: str):
     dispatcher.add_handler(MessageHandler(Filters.status_update.new_chat_members, bot.new_member))
     dispatcher.add_handler(MessageHandler(Filters.status_update.new_chat_title, bot.new_chat_title))
     dispatcher.add_handler(MessageHandler(Filters.status_update.chat_created, bot.chat_created))
+    dispatcher.add_handler(MessageHandler(Filters.status_update.migrate, bot.migrate_chat_id))
 
     logger.debug(f"Read state from {state_file}")
     if os.path.exists(state_file):

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -401,6 +401,16 @@ class Bot:
     def chat_created(self, update: Update, context: CallbackContext):
         self.update_hhh_message(context.chat_data["chat"], "")
 
+    @Command()
+    def migrate_chat_id(self, update: Update, context: CallbackContext):
+        self.logger.debug(f"Migrating {update.effective_message}")
+        from_id: str = str(update.effective_message.migrate_from_chat_id)  # should be an int
+        to_id: int = int(update.effective_message.migrate_to_chat_id)  # should already be an int
+
+        self.logger.debug(f"Update chat_id to {to_id} (was: {from_id})")
+        context.chat_data["chat"].id = to_id
+        self.chats[from_id].id = to_id
+
 
 def _split_messages(lines):
     message_length = 1024

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -404,12 +404,16 @@ class Bot:
     @Command()
     def migrate_chat_id(self, update: Update, context: CallbackContext):
         self.logger.debug(f"Migrating {update.effective_message}")
-        from_id: str = str(update.effective_message.migrate_from_chat_id)  # should be an int
-        to_id: int = int(update.effective_message.migrate_to_chat_id)  # should already be an int
+        from_id = str(update.effective_message.migrate_from_chat_id)
+        to_id = str(update.effective_message.migrate_to_chat_id)
 
         self.logger.debug(f"Update chat_id to {to_id} (was: {from_id})")
-        context.chat_data["chat"].id = to_id
-        self.chats[from_id].id = to_id
+        new_chat = context.chat_data["chat"]
+        new_chat.id = to_id
+
+        context.chat_data["chat"] = new_chat
+        self.chats[to_id] = new_chat
+        self.chats.pop(from_id)
 
 
 def _split_messages(lines):


### PR DESCRIPTION
Adds a `migrate` fitler and a method which updates `Chat.id` in `context.chat_data` and `Bot.chats`.

Remove old id from `Bot.chats`.

Closes #20 