### PR TITLE
Add cleanup function for state file

### DIFF
--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -151,7 +151,7 @@ class Bot:
         text: str = ""
 
         for _, g in groupby(
-                sorted([chat for _, chat in self.chats.items() if chat.title], key=lambda c: c.title.lower()),
+                sorted([chat for _, chat in self.chats.items() if chat and chat.title], key=lambda c: c.title.lower()),
                 key=lambda c: c.title[0].lower()):
             text += " | ".join([chat.title for chat in g]) + "\n"
 

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -465,7 +465,7 @@ class Bot:
     @Command()
     def renew_diff_message(self, update: Update, context: CallbackContext):
         self.state["group_message_id"] = ""
-        self.update_hhh_message(context.chat_data["chat"], "")
+        self.update_hhh_message(context.chat_data["chat"], "", retry=True)
 
 
 def _split_messages(lines):


### PR DESCRIPTION
Cleanup state file on startup.

Currently:
- dedups chats where both an `id: int` and `id: str` are present.
- deletes chats where `id is None` or `id == 'None'`